### PR TITLE
feat(parse): allow whitespace in key

### DIFF
--- a/__tests__/fixtures/issues/spaces-tabs.md
+++ b/__tests__/fixtures/issues/spaces-tabs.md
@@ -1,2 +1,2 @@
 name: Mona
-color: royal blue
+favorite color: royal blue

--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -49,7 +49,7 @@ describe('default regex', () => {
     const body = loadFixture('issues/leading-whitespace.md')
     const params = new Map<string, string>([
       ['name', 'Mona'],
-      ['color', 'blue']
+      ['favorite color', 'blue']
     ])
     expect(parse(body)).toEqual(params)
   })
@@ -63,20 +63,11 @@ describe('default regex', () => {
     expect(parse(body)).toEqual(params)
   })
 
-  test('matches spaces and tabs as value', () => {
+  test('matches spaces and tabs in key and value', () => {
     const body = loadFixture('issues/spaces-tabs.md')
     const params = new Map<string, string>([
       ['name', 'Mona'],
-      ['color', 'royal blue']
-    ])
-    expect(parse(body)).toEqual(params)
-  })
-
-  test('does not match spaces and tabs in key', () => {
-    const body = loadFixture('issues/spaces-tabs.md')
-    const params = new Map<string, string>([
-      ['name', 'Mona'],
-      ['color', 'royal blue']
+      ['favorite color', 'royal blue']
     ])
     expect(parse(body)).toEqual(params)
   })

--- a/dist/index.js
+++ b/dist/index.js
@@ -3091,7 +3091,7 @@ module.exports = opts => {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = __webpack_require__(611);
-const regex = /\s*(?<key>[\w]+)\s*:\s*(?<value>[\w\t ]+)\s*/gm;
+const regex = /\s*(?<key>[\w\t ]+)\s*:\s*(?<value>[\w\t ]+)\s*/gm;
 function parseExtractions(body) {
     const params = new Map();
     const extractions = utils_1.getExtractions();

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,6 @@
 import {getExtractions, getFirstMatch} from './utils'
 
-const regex = /\s*(?<key>[\w]+)\s*:\s*(?<value>[\w\t ]+)\s*/gm
+const regex = /\s*(?<key>[\w\t ]+)\s*:\s*(?<value>[\w\t ]+)\s*/gm
 
 export function parseExtractions(body: string): Map<string, string> {
   const params = new Map<string, string>()


### PR DESCRIPTION
default usage should allow whitespace in the key as we do this in the value already